### PR TITLE
(fix): bug on chapter 4 flag conversion

### DIFF
--- a/Flag.cs
+++ b/Flag.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DeltaruneSaveConverter;
+
+public class Flag
+{
+ 
+    public static void ParseFlagArray(string listhex, ref double[] output, int length)
+    {
+        byte[] rawlist = new byte[listhex.Length / 2];
+        for (int i = 0; i < listhex.Length; i += 2)
+        {
+            rawlist[i / 2] = Convert.ToByte(listhex.Substring(i, 2), 16);
+        }
+
+        int byteIndex = 8;
+    
+        for (int i = 0; i < length; i++)
+        {
+            if (byteIndex + 8 > rawlist.Length) break;
+
+            output[i] = BitConverter.ToDouble(rawlist, byteIndex);
+        
+            byteIndex += 8;
+        }
+    }
+}


### PR DESCRIPTION
Following the last 2 issues reported, after some tinkering and ai assisted troubleshooting I came up with a solution.

The converter crashed with an "Unknown list type" exception. It mistakenly evaluated raw array data as a GameMaker ds_list, expecting type markers before each element, which caused severe byte misalignment.

Changes:

- Agentically Recognised that flag data is a standard contiguous array of 64-bit floats, not a ds_list.

- Handled edge cases by adding a dedicated ParseFlagArray method.
(Bypassed the ds_list behaviour to skip the initial 8-byte header and parse the 8-byte blocks directly into double values.)

NOTE: i would like to contribute in rewriting and further tidying up code as soon as possible