### PR TITLE
Add Chapter 5 save file support (filech5)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -136,7 +136,7 @@ namespace DeltaruneSaveConverter
                         return;
                     }
                 }
-                else if (filename.StartsWith("filech2") || filename.StartsWith("filech3") || filename.StartsWith("filech4")) // assume this is a console save file from Chapter 2
+                else if (filename.StartsWith("filech2") || filename.StartsWith("filech3") || filename.StartsWith("filech4") || filename.StartsWith("filech5")) // assume this is a console save file from Chapter 2
                 {
                     try
                     {
@@ -187,7 +187,7 @@ namespace DeltaruneSaveConverter
                         return;
                     }
                 }
-                else if (filename.StartsWith("filech2") || filename.StartsWith("filech3") || filename.StartsWith("filech4")) // assume this is a PC save file from Chapter 2
+                else if (filename.StartsWith("filech2") || filename.StartsWith("filech3") || filename.StartsWith("filech4") || filename.StartsWith("filech5")) // assume this is a PC save file from Chapter 2
                 {
                     try
                     {
@@ -381,6 +381,34 @@ namespace DeltaruneSaveConverter
                         ini.Write("InitLang", $"\"{save.flag[912]}\"", $"G_4_{saveid}");
                         int uraboss = (int)save.flag[1629];
                         ini.Write("UraBoss", $"\"{uraboss}\"", $"G_4_{saveid}");
+                        Console.WriteLine("done!");
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"error: {ex.Message}");
+                        return;
+                    }
+                }
+                else if (filename.StartsWith("filech5")) // assume this is a PC save file from Chapter 5
+                {
+                    try
+                    {
+                        Console.Write($"Reading {filename}... ");
+                        DeltaruneCh2 save = new();
+                        save.ReadFromPCFile(file);
+                        Console.WriteLine("done!");
+                        Console.Write($"Writing \"{save.truename}\" chapter 5 save to INI... ");
+                        int saveid = int.Parse(filename.Replace("filech5_", ""));
+                        if (saveid >= 3 && saveid < 6)
+                            status = 1; // game complete, set console-only STATUS variable
+                        ini.Write("Name", save.truename, $"G_5_{saveid}");
+                        ini.Write("Level", $"\"{save.lv}\"", $"G_5_{saveid}");
+                        ini.Write("Love", $"\"{save.llv}\"", $"G_5_{saveid}");
+                        ini.Write("Time", $"\"{save.time}\"", $"G_5_{saveid}");
+                        ini.Write("Date", $"\"0\"", $"G_5_{saveid}"); // TODO: Get valid date value
+                        ini.Write("Room", $"\"{save.currentroom}\"", $"G_5_{saveid}");
+                        ini.Write("InitLang", $"\"{save.flag[912]}\"", $"G_5_{saveid}");
+                        ini.Write("UraBoss", $"\"0\"", $"G_5_{saveid}");
                         Console.WriteLine("done!");
                     }
                     catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -408,7 +408,8 @@ namespace DeltaruneSaveConverter
                         ini.Write("Date", $"\"0\"", $"G_5_{saveid}"); // TODO: Get valid date value
                         ini.Write("Room", $"\"{save.currentroom}\"", $"G_5_{saveid}");
                         ini.Write("InitLang", $"\"{save.flag[912]}\"", $"G_5_{saveid}");
-                        ini.Write("UraBoss", $"\"0\"", $"G_5_{saveid}");
+                        int uraboss = (int)save.flag[1908];
+                        ini.Write("UraBoss", $"\"{uraboss}\"", $"G_5_{saveid}");
                         Console.WriteLine("done!");
                     }
                     catch (Exception ex)


### PR DESCRIPTION
The converter only handled filech1-filech4, skipping filech5_0 and filech5_9. This adds filech5 to the conditions in ConvertFromConsole, ConvertFromPC, and BuildINI, using the DeltaruneCh2 format (same as ch2-ch4).